### PR TITLE
Fix add child returns error: Value cannot be null

### DIFF
--- a/scripts/linksManager.ts
+++ b/scripts/linksManager.ts
@@ -204,11 +204,6 @@ export async function createChildWi(trigger: string, childTitle: string) {
             } as JsonPatchOperation,
             {
                 op: Operation.Add,
-                path: `/fields/${assignedTo}`,
-                value: (await service.getFieldValue(assignedTo)) as string,
-            } as JsonPatchDocument,
-            {
-                op: Operation.Add,
                 path: "/relations/-",
                 value: {
                     rel: "System.LinkTypes.Hierarchy-Reverse",
@@ -219,6 +214,10 @@ export async function createChildWi(trigger: string, childTitle: string) {
                 },
             } as JsonPatchOperation,
         ] as JsonPatchDocument & JsonPatchOperation[];
+        const assignee = (await service.getFieldValue(assignedTo)) as string;
+        if (assignee) {
+            patch.push({ op: Operation.Add, path: `/fields/${assignedTo}`, value: assignee } as JsonPatchOperation);
+        }
         setStatus("Creating work item...");
         const child = await getClient().createWorkItem(patch, project, childWitName);
         rels.push({url: child.url, rel: "System.LinkTypes.Hierarchy-Forward"} as WorkItemRelation);

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "links-group",
-    "version": "1.0.50",
+    "version": "1.0.51",
     "name": "Links Group",
     "scopes": [ "vso.work", "vso.work_write" ],
     "description": "Update links from first page of the work item form.",


### PR DESCRIPTION
Fixes #40 Add child causes error

Checks for a null return value when getting the assignedTo field from the parent work item.  Only sets the child work item's assignedTo value if the parent work item has an assignee.